### PR TITLE
Implemented Endpoint for Game Category Creation for Admin Only

### DIFF
--- a/src/games/controllers/game-categories.controller.ts
+++ b/src/games/controllers/game-categories.controller.ts
@@ -18,12 +18,25 @@ import {
   ApiParam,
 } from '@nestjs/swagger';
 import { GameCategoriesService } from '../providers/game-categories.service';
-
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { CreateCategoryDto } from '../dto/create-category.dto';
 
 @ApiTags('game-categories')
 @Controller('game-categories')
 export class GameCategoriesController {
   constructor(private readonly categoriesService: GameCategoriesService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a new game category' })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'The game category has been successfully created.',
+  })
+  create(@Body() createCategoryDto: CreateCategoryDto) {
+    return this.categoriesService.create(createCategoryDto);
+  }
 
   @Get()
   @ApiOperation({ summary: 'Get all game categories' })

--- a/src/games/providers/game-categories.service.ts
+++ b/src/games/providers/game-categories.service.ts
@@ -18,6 +18,31 @@ export class GameCategoriesService {
     private readonly gamesRepository: Repository<Game>,
   ) {}
 
+    async create(createCategoryDto: CreateCategoryDto): Promise<GameCategory> {
+    // Check if name or slug already exists
+    const existingCategory = await this.categoriesRepository.findOne({
+      where: [
+        { name: createCategoryDto.name },
+        { slug: createCategoryDto.slug },
+      ],
+    });
+
+    if (existingCategory) {
+      if (existingCategory.name === createCategoryDto.name) {
+        throw new ConflictException(
+          `Category with name '${createCategoryDto.name}' already exists`,
+        );
+      } else {
+        throw new ConflictException(
+          `Category with slug '${createCategoryDto.slug}' already exists`,
+        );
+      }
+    }
+
+    const category = this.categoriesRepository.create(createCategoryDto);
+    return this.categoriesRepository.save(category);
+  }
+
   async findAll(): Promise<GameCategory[]> {
     return this.categoriesRepository.find({
       order: { name: 'ASC' },


### PR DESCRIPTION
This PR  implements the POST /game-categories endpoint for creating new game categories. 

This endpoint is restricted to admin users only, allowing them to manage the categories in which different games can be classified.


closes #30 