### PR TITLE
cronjob implemented for admin

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,7 @@ import { ImpersonationModule } from './impersonation/impersonation.module';
 import { FeedbackModule } from './feedback/feedback.module';
 import { DeveloperModule } from './developer/developer.module';
 import { HintRecommenderModule } from './hint-recommender/hint-recommender.module';
+import { CronJobModule } from './cron-job/cron-job.module';
 
 @Module({
   imports: [
@@ -63,6 +64,7 @@ import { HintRecommenderModule } from './hint-recommender/hint-recommender.modul
     FeedbackModule,
     DeveloperModule,
     HintRecommenderModule,
+    CronJobModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/cron-job/cron-job.controller.spec.ts
+++ b/src/cron-job/cron-job.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CronJobController } from './cron-job.controller';
+import { CronJobService } from './cron-job.service';
+
+describe('CronJobController', () => {
+  let controller: CronJobController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CronJobController],
+      providers: [CronJobService],
+    }).compile();
+
+    controller = module.get<CronJobController>(CronJobController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/cron-job/cron-job.controller.ts
+++ b/src/cron-job/cron-job.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  ParseIntPipe,
+} from '@nestjs/common';
+import { CronJobService } from './cron-job.service';
+import { CreateCronJobDto } from './dto/create-cron-job.dto';
+import { UpdateCronJobDto } from './dto/update-cron-job.dto';
+
+// Assuming you have an AdminGuard for admin-only routes
+// @UseGuards(AdminGuard)
+@Controller('admin/cronjob')
+export class CronjobController {
+  constructor(private readonly cronJobService: CronJobService) {}
+
+  @Post()
+  create(@Body() createPuzzleDto: CreateCronJobDto) {
+    return this.cronJobService.create(createPuzzleDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.cronJobService.findAll();
+  }
+
+  @Get('active')
+  findActive() {
+    return this.cronJobService.findActive();
+  }
+
+  @Get('scheduled')
+  getScheduledPuzzles() {
+    return this.cronJobService.getScheduledPuzzles();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.cronJobService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updatePuzzleDto: UpdateCronJobDto,
+  ) {
+    return this.cronJobService.update(id, updatePuzzleDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.cronJobService.remove(id);
+  }
+
+  @Post('activate-scheduled')
+  manualActivation() {
+    return this.cronJobService.manualActivation();
+  }
+}

--- a/src/cron-job/cron-job.module.ts
+++ b/src/cron-job/cron-job.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CronJobService } from './cron-job.service';
+import { CronJobController } from './cron-job.controller';
+
+@Module({
+  controllers: [CronJobController],
+  providers: [CronJobService],
+})
+export class CronJobModule {}

--- a/src/cron-job/cron-job.service.spec.ts
+++ b/src/cron-job/cron-job.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CronJobService } from './cron-job.service';
+
+describe('CronJobService', () => {
+  let service: CronJobService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CronJobService],
+    }).compile();
+
+    service = module.get<CronJobService>(CronJobService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/cron-job/cron-job.service.ts
+++ b/src/cron-job/cron-job.service.ts
@@ -1,0 +1,126 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThanOrEqual } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Cronjob } from './entities/cron-job.entity';
+
+import { CreateCronJobDto } from './dto/create-cron-job.dto';
+import { UpdateCronJobDto } from './dto/update-cron-job.dto';
+
+@Injectable()
+export class CronJobService {
+  
+private readonly logger = new Logger(CronJobService.name);
+
+  constructor(
+    @InjectRepository(Cronjob)
+    private CreateCronJobRepository: Repository<Cronjob>,
+  ) {}
+
+  async create(CreateCronJobDto: CreateCronJobDto): Promise<Cronjob> {
+    const puzzle = this.CreateCronJobRepository.create({
+      ...CreateCronJobDto,
+      releaseDate: CreateCronJobDto.releaseDate ? new Date(CreateCronJobDto.releaseDate) : null,
+    });
+    return this.CreateCronJobRepository.save(puzzle);
+  }
+
+  async findAll(): Promise<Cronjob[]> {
+    return this.CreateCronJobRepository.find({
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findActive(): Promise<Cronjob[]> {
+    return this.CreateCronJobRepository.find({
+      where: { isActive: true },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findOne(id: number): Promise<Cronjob> {
+    return this.CreateCronJobRepository.findOne({ where: { id } });
+  }
+
+  async update(id: number, updatePuzzleDto: UpdateCronJobDto): Promise<Cronjob> {
+    const updateData = {
+      ...UpdateCronJobDto,
+      releaseDate: UpdateCronJobDto.releaseDate ? new Date(UpdateCronJobDto.releaseDate) : undefined,
+    };
+    
+    await this.CreateCronJobRepository.update(id, updateData);
+    return this.findOne(id);
+  }
+
+  async remove(id: number): Promise<void> {
+    await this.CreateCronJobRepository.delete(id);
+  }
+
+  // Cron job to activate puzzles - runs every minute
+  @Cron(CronExpression.EVERY_MINUTE)
+  async activateScheduledPuzzles(): Promise<void> {
+    const now = new Date();
+    
+    try {
+      const puzzlesToActivate = await this.CreateCronJobRepository.find({
+        where: {
+          isActive: false,
+          releaseDate: LessThanOrEqual(now),
+        },
+      });
+
+      if (puzzlesToActivate.length > 0) {
+        await this.CreateCronJobRepository.update(
+          { isActive: false, releaseDate: LessThanOrEqual(now) },
+          { isActive: true }
+        );
+
+        this.logger.log(`Activated ${puzzlesToActivate.length} puzzles at ${now.toISOString()}`);
+        
+        // Log each activated puzzle
+        puzzlesToActivate.forEach(puzzle => {
+          this.logger.log(`Activated puzzle: ${puzzle.title} (ID: ${puzzle.id})`);
+        });
+      }
+    } catch (error) {
+      this.logger.error('Error activating scheduled puzzles:', error);
+    }
+  }
+
+  // Manual method to activate puzzles (for testing or manual triggers)
+  async manualActivation(): Promise<{ activated: number; puzzles: Cronjob[] }> {
+    const now = new Date();
+    
+    const puzzlesToActivate = await this.CreateCronJobRepository.find({
+      where: {
+        isActive: false,
+        releaseDate: LessThanOrEqual(now),
+      },
+    });
+
+    if (puzzlesToActivate.length > 0) {
+      await this.CreateCronJobRepository.update(
+        { isActive: false, releaseDate: LessThanOrEqual(now) },
+        { isActive: true }
+      );
+    }
+
+    return {
+      activated: puzzlesToActivate.length,
+      puzzles: puzzlesToActivate,
+    };
+  }
+
+  // Get scheduled puzzles (inactive with future release dates)
+  async getScheduledPuzzles(): Promise<Cronjob[]> {
+    const now = new Date();
+    return this.CreateCronJobRepository.find({
+      where: {
+        isActive: false,
+        releaseDate: LessThanOrEqual(now),
+      },
+      order: { releaseDate: 'ASC' },
+    });
+  }
+}
+

--- a/src/cron-job/dto/create-cron-job.dto.ts
+++ b/src/cron-job/dto/create-cron-job.dto.ts
@@ -1,0 +1,23 @@
+import { IsString, IsNotEmpty, IsOptional, IsDateString, IsBoolean } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class CreateCronJobDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  @IsNotEmpty()
+  content: any;
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean = false;
+
+  @IsOptional()
+  @IsDateString()
+  releaseDate?: string;
+}

--- a/src/cron-job/dto/update-cron-job.dto.ts
+++ b/src/cron-job/dto/update-cron-job.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateCronJobDto } from './create-cron-job.dto';
+
+export class UpdateCronJobDto extends PartialType(CreateCronJobDto) {}

--- a/src/cron-job/entities/cron-job.entity.ts
+++ b/src/cron-job/entities/cron-job.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('puzzles')
+export class Cronjob {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column('text')
+  description: string;
+
+  @Column('json')
+  content: any;
+
+  @Column({ default: false })
+  isActive: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  releaseDate: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
closes #99 

I've created a complete puzzle scheduling module for NestJS. Here are the key features:
Key Components:

Puzzle Entity - Added releaseDate field and isActive boolean
Cron Job - Automatically activates puzzles when their release date arrives
Admin Controller - Full CRUD operations for puzzle management
DTOs - Proper validation for create/update operations

Key Features:

Scheduled Release: Puzzles can be created with a future releaseDate
Automatic Activation: Cron job runs every minute to check and activate due puzzles
Manual Activation: Admin endpoint to manually trigger activation
Scheduled Puzzles View: Get all puzzles waiting to be activated