### PR TITLE
feat: add validators module with address validation logic and controller

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { ProgressModule } from './progress/progress.module';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ValidatorsModule } from './validators/validators.module';
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -41,6 +42,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     UserModule,
     ProgressModule,
     DailyChallengeModule,
+    ValidatorsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/validators/dtos/validate-address.dto.ts
+++ b/src/validators/dtos/validate-address.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsNotEmpty, IsArray, ArrayNotEmpty } from 'class-validator';
+
+export class ValidateAddressDto {
+  @IsNotEmpty()
+  @IsString()
+  address: string;
+}
+
+export class ValidateMultipleAddressesDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  addresses: string[];
+}

--- a/src/validators/starknet-address.validator.ts
+++ b/src/validators/starknet-address.validator.ts
@@ -1,0 +1,234 @@
+import { Injectable } from '@nestjs/common';
+
+export interface StarkNetAddressValidationResult {
+  isValid: boolean;
+  format?: 'hex' | 'decimal';
+  normalizedAddress?: string;
+  errors?: string[];
+}
+
+@Injectable()
+export class StarkNetAddressValidator {
+  private readonly HEX_PREFIX = '0x';
+  private readonly MIN_ADDRESS_LENGTH = 3; // 0x + at least 1 hex digit
+  private readonly MAX_ADDRESS_LENGTH = 66; // 0x + 64 hex digits (256 bits)
+  private readonly MAX_DECIMAL_LENGTH = 78; // Max decimal representation of 2^256
+
+  /**
+   * Validates a StarkNet wallet address
+   * @param address - The address to validate
+   * @returns Validation result with details
+   */
+  public validateAddress(address: string): StarkNetAddressValidationResult {
+    // Basic null/undefined check
+    if (!address) {
+      return {
+        isValid: false,
+        errors: ['Address is required'],
+      };
+    }
+
+    // Trim whitespace
+    const trimmedAddress = address.trim();
+
+    if (trimmedAddress.length === 0) {
+      return {
+        isValid: false,
+        errors: ['Address cannot be empty'],
+      };
+    }
+
+    // Check if it's hexadecimal format
+    if (this.isHexFormat(trimmedAddress)) {
+      return this.validateHexAddress(trimmedAddress);
+    }
+
+    // Check if it's decimal format
+    if (this.isDecimalFormat(trimmedAddress)) {
+      return this.validateDecimalAddress(trimmedAddress);
+    }
+
+    return {
+      isValid: false,
+      errors: [
+        'Invalid address format. Must be hexadecimal (0x...) or decimal number',
+      ],
+    };
+  }
+
+  /**
+   * Validates multiple addresses at once
+   * @param addresses - Array of addresses to validate
+   * @returns Array of validation results
+   */
+  public validateMultipleAddresses(
+    addresses: string[],
+  ): StarkNetAddressValidationResult[] {
+    return addresses.map((address) => this.validateAddress(address));
+  }
+
+  /**
+   * Checks if all provided addresses are valid
+   * @param addresses - Array of addresses to validate
+   * @returns True if all addresses are valid
+   */
+  public areAllAddressesValid(addresses: string[]): boolean {
+    return addresses.every((address) => this.validateAddress(address).isValid);
+  }
+
+  /**
+   * Normalizes a valid address to hexadecimal format
+   * @param address - The address to normalize
+   * @returns Normalized address or null if invalid
+   */
+  public normalizeAddress(address: string): string | null {
+    const validation = this.validateAddress(address);
+    return validation.isValid ? validation.normalizedAddress! : null;
+  }
+
+  private isHexFormat(address: string): boolean {
+    return address.toLowerCase().startsWith(this.HEX_PREFIX.toLowerCase());
+  }
+
+  private isDecimalFormat(address: string): boolean {
+    return /^\d+$/.test(address);
+  }
+
+  private validateHexAddress(address: string): StarkNetAddressValidationResult {
+    const errors: string[] = [];
+    const lowerAddress = address.toLowerCase();
+
+    // Check length constraints
+    if (lowerAddress.length < this.MIN_ADDRESS_LENGTH) {
+      errors.push('Hex address too short');
+    }
+
+    if (lowerAddress.length > this.MAX_ADDRESS_LENGTH) {
+      errors.push('Hex address too long');
+    }
+
+    // Validate hex characters after 0x prefix
+    const hexPart = lowerAddress.slice(2);
+    if (!/^[0-9a-f]*$/.test(hexPart)) {
+      errors.push('Invalid hexadecimal characters');
+    }
+
+    // Check if it's all zeros (invalid address)
+    if (hexPart.length > 0 && /^0+$/.test(hexPart)) {
+      errors.push('Address cannot be zero');
+    }
+
+    if (errors.length > 0) {
+      return {
+        isValid: false,
+        errors,
+      };
+    }
+
+    // Normalize: ensure proper case and remove unnecessary leading zeros
+    const normalizedHex = this.normalizeHexAddress(lowerAddress);
+
+    return {
+      isValid: true,
+      format: 'hex',
+      normalizedAddress: normalizedHex,
+    };
+  }
+
+  private validateDecimalAddress(
+    address: string,
+  ): StarkNetAddressValidationResult {
+    const errors: string[] = [];
+
+    // Check length
+    if (address.length > this.MAX_DECIMAL_LENGTH) {
+      errors.push('Decimal address too long');
+    }
+
+    // Check if it's zero
+    if (address === '0' || /^0+$/.test(address)) {
+      errors.push('Address cannot be zero');
+    }
+
+    // Validate it's within the valid range (less than 2^251)
+    // StarkNet uses a prime field, so we need to check the maximum value
+    try {
+      const bigIntAddress = BigInt(address);
+      const maxValue = BigInt('2') ** BigInt('251'); // StarkNet field prime is close to 2^251
+
+      if (bigIntAddress >= maxValue) {
+        errors.push('Address exceeds maximum allowed value');
+      }
+    } catch {
+      errors.push('Invalid decimal number');
+    }
+
+    if (errors.length > 0) {
+      return {
+        isValid: false,
+        errors,
+      };
+    }
+
+    // Convert to normalized hex format
+    const bigIntAddress = BigInt(address);
+    const normalizedHex = '0x' + bigIntAddress.toString(16);
+
+    return {
+      isValid: true,
+      format: 'decimal',
+      normalizedAddress: normalizedHex,
+    };
+  }
+
+  private normalizeHexAddress(hexAddress: string): string {
+    // Remove 0x prefix, remove leading zeros, then add back 0x
+    const hexPart = hexAddress.slice(2);
+    const withoutLeadingZeros = hexPart.replace(/^0+/, '') || '0';
+    return '0x' + withoutLeadingZeros;
+  }
+
+  /**
+   * Utility method to check if an address is in canonical format
+   * @param address - The address to check
+   * @returns True if address is in canonical format
+   */
+  public isCanonicalFormat(address: string): boolean {
+    const validation = this.validateAddress(address);
+    if (!validation.isValid) {
+      return false;
+    }
+    return address === validation.normalizedAddress;
+  }
+
+  /**
+   * Get address information
+   * @param address - The address to analyze
+   * @returns Detailed information about the address
+   */
+  public getAddressInfo(address: string): {
+    isValid: boolean;
+    format?: 'hex' | 'decimal';
+    length?: number;
+    isCanonical?: boolean;
+    normalizedAddress?: string;
+    errors?: string[];
+  } {
+    const validation = this.validateAddress(address);
+
+    if (!validation.isValid) {
+      return {
+        isValid: false,
+        errors: validation.errors,
+      };
+    }
+
+    return {
+      isValid: true,
+      format: validation.format,
+      length: address.length,
+      isCanonical: this.isCanonicalFormat(address),
+      normalizedAddress: validation.normalizedAddress,
+    };
+  }
+}

--- a/src/validators/validators.controller.ts
+++ b/src/validators/validators.controller.ts
@@ -1,0 +1,73 @@
+// src/validators/validators.controller.ts
+import { Body, Controller, Post, Get, Param } from '@nestjs/common';
+import {
+  StarkNetAddressValidator,
+  StarkNetAddressValidationResult,
+} from './starknet-address.validator';
+import {
+  ValidateAddressDto,
+  ValidateMultipleAddressesDto,
+} from './dtos/validate-address.dto';
+import { Public } from 'src/auth/decorators/auth.decorators';
+
+@Controller('validators')
+export class ValidatorsController {
+  constructor(private readonly starkNetValidator: StarkNetAddressValidator) {}
+
+  @Public()
+  @Post('starknet/validate')
+  validateAddress(
+    @Body() validateAddressDto: ValidateAddressDto,
+  ): StarkNetAddressValidationResult {
+    return this.starkNetValidator.validateAddress(validateAddressDto.address);
+  }
+
+  @Public()
+  @Post('starknet/validate-multiple')
+  validateMultipleAddresses(
+    @Body() validateMultipleDto: ValidateMultipleAddressesDto,
+  ): {
+    results: StarkNetAddressValidationResult[];
+    summary: {
+      total: number;
+      valid: number;
+      invalid: number;
+    };
+  } {
+    const results = this.starkNetValidator.validateMultipleAddresses(
+      validateMultipleDto.addresses,
+    );
+    const validCount = results.filter((r) => r.isValid).length;
+
+    return {
+      results,
+      summary: {
+        total: results.length,
+        valid: validCount,
+        invalid: results.length - validCount,
+      },
+    };
+  }
+
+  @Public()
+  @Get('starknet/normalize/:address')
+  normalizeAddress(@Param('address') address: string): {
+    originalAddress: string;
+    normalizedAddress: string | null;
+    isValid: boolean;
+  } {
+    const normalizedAddress = this.starkNetValidator.normalizeAddress(address);
+
+    return {
+      originalAddress: address,
+      normalizedAddress,
+      isValid: normalizedAddress !== null,
+    };
+  }
+
+  @Public()
+  @Get('starknet/info/:address')
+  getAddressInfo(@Param('address') address: string) {
+    return this.starkNetValidator.getAddressInfo(address);
+  }
+}

--- a/src/validators/validators.module.ts
+++ b/src/validators/validators.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { StarkNetAddressValidator } from './starknet-address.validator';
+import { ValidatorsController } from './validators.controller';
+
+@Module({
+  providers: [StarkNetAddressValidator],
+  controllers: [ValidatorsController],
+  exports: [StarkNetAddressValidator],
+})
+export class ValidatorsModule {}

--- a/src/validators/validators.service.spec.ts
+++ b/src/validators/validators.service.spec.ts
@@ -1,0 +1,118 @@
+// src/validators/validators.service.spec.ts (Test file)
+import { Test, TestingModule } from '@nestjs/testing';
+import { StarkNetAddressValidator } from './starknet-address.validator';
+
+describe('StarkNetAddressValidator', () => {
+  let validator: StarkNetAddressValidator;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [StarkNetAddressValidator],
+    }).compile();
+
+    validator = module.get<StarkNetAddressValidator>(StarkNetAddressValidator);
+  });
+
+  describe('validateAddress', () => {
+    it('should validate correct hex addresses', () => {
+      const validHexAddresses = [
+        '0x1',
+        '0x123',
+        '0x1234567890abcdef',
+        '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7',
+      ];
+
+      validHexAddresses.forEach((address) => {
+        const result = validator.validateAddress(address);
+        expect(result.isValid).toBe(true);
+        expect(result.format).toBe('hex');
+        expect(result.normalizedAddress).toBeDefined();
+      });
+    });
+
+    it('should validate correct decimal addresses', () => {
+      const validDecimalAddresses = [
+        '1',
+        '123456789',
+        '2087021424722619777119509474943472645767659996348769578120564519014510906823',
+      ];
+
+      validDecimalAddresses.forEach((address) => {
+        const result = validator.validateAddress(address);
+        expect(result.isValid).toBe(true);
+        expect(result.format).toBe('decimal');
+        expect(result.normalizedAddress).toBeDefined();
+      });
+    });
+
+    it('should reject invalid addresses', () => {
+      const invalidAddresses = [
+        '',
+        '0x',
+        '0xzz',
+        '0x' + 'a'.repeat(65), // Too long
+        '0',
+        'invalid',
+        '0x0000000000000000000000000000000000000000000000000000000000000000', // All zeros
+      ];
+
+      invalidAddresses.forEach((address) => {
+        const result = validator.validateAddress(address);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toBeDefined();
+        expect(result.errors!.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should normalize addresses correctly', () => {
+      const testCases = [
+        { input: '0x001', expected: '0x1' },
+        { input: '0x0000123', expected: '0x123' },
+        { input: '123', expected: '0x7b' }, // 123 in decimal = 7b in hex
+      ];
+
+      testCases.forEach(({ input, expected }) => {
+        const result = validator.validateAddress(input);
+        expect(result.isValid).toBe(true);
+        expect(result.normalizedAddress).toBe(expected);
+      });
+    });
+  });
+
+  describe('validateMultipleAddresses', () => {
+    it('should validate multiple addresses', () => {
+      const addresses = ['0x1', '0x123', 'invalid', '456'];
+      const results = validator.validateMultipleAddresses(addresses);
+
+      expect(results).toHaveLength(4);
+      expect(results[0].isValid).toBe(true); // 0x1
+      expect(results[1].isValid).toBe(true); // 0x123
+      expect(results[2].isValid).toBe(false); // invalid
+      expect(results[3].isValid).toBe(true); // 456
+    });
+  });
+
+  describe('normalizeAddress', () => {
+    it('should return normalized address for valid inputs', () => {
+      expect(validator.normalizeAddress('0x001')).toBe('0x1');
+      expect(validator.normalizeAddress('123')).toBe('0x7b');
+    });
+
+    it('should return null for invalid inputs', () => {
+      expect(validator.normalizeAddress('invalid')).toBeNull();
+      expect(validator.normalizeAddress('')).toBeNull();
+    });
+  });
+
+  describe('areAllAddressesValid', () => {
+    it('should return true when all addresses are valid', () => {
+      const validAddresses = ['0x1', '0x123', '456'];
+      expect(validator.areAllAddressesValid(validAddresses)).toBe(true);
+    });
+
+    it('should return false when any address is invalid', () => {
+      const mixedAddresses = ['0x1', 'invalid', '456'];
+      expect(validator.areAllAddressesValid(mixedAddresses)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #133

Added pure validation service for StarkNet wallet addresses with no external dependencies:

- ✅ Validates both hexadecimal (0x...) and decimal address formats
- ✅ Address normalization and canonicalization 
- ✅ Comprehensive validation (format, length, range checks)
- ✅ REST API endpoints for validation operations
- ✅ Unit tests included
- ✅ No external dependencies - pure TypeScript implementation

API endpoints:
- `POST /validators/starknet/validate` - Single address validation
- `POST /validators/starknet/validate-multiple` - Batch validation
- `GET /validators/starknet/normalize/:address` - Address normalization
- `GET /validators/starknet/info/:address` - Detailed address info