### PR TITLE
feat: Implement Puzzle Timer module with CRUD operations and DTOs

### DIFF
--- a/src/puzzle-timers/dto/create-puzzle-timer.dto.ts
+++ b/src/puzzle-timers/dto/create-puzzle-timer.dto.ts
@@ -1,0 +1,16 @@
+
+import { IsDateString, IsNotEmpty, IsUUID } from 'class-validator';
+
+export class CreatePuzzleTimerDto {
+  @IsDateString()
+  @IsNotEmpty()
+  readonly startTime: string;
+
+  @IsDateString()
+  @IsNotEmpty()
+  readonly endTime: string;
+
+  @IsUUID()
+  @IsNotEmpty()
+  readonly challengeId: string;
+}

--- a/src/puzzle-timers/dto/update-puzzle-timer.dto.ts
+++ b/src/puzzle-timers/dto/update-puzzle-timer.dto.ts
@@ -1,0 +1,6 @@
+// src/puzzle-timers/dto/update-puzzle-timer.dto.ts
+
+import { PartialType } from '@nestjs/mapped-types';
+import { CreatePuzzleTimerDto } from './create-puzzle-timer.dto';
+
+export class UpdatePuzzleTimerDto extends PartialType(CreatePuzzleTimerDto) {}

--- a/src/puzzle-timers/entities/puzzle-timer.entity.ts
+++ b/src/puzzle-timers/entities/puzzle-timer.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('puzzle_timers')
+export class PuzzleTimer {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'timestamptz', comment: 'The moment the timer starts' })
+  startTime: Date;
+
+  @Column({ type: 'timestamptz', comment: 'The moment the timer ends' })
+  endTime: Date;
+
+  @Index()
+  @Column({ type: 'uuid', comment: 'The associated challenge ID' })
+  challengeId: string;
+  // Note: In a full-fledged app, this would be a @ManyToOne relationship
+  // to a Challenge entity. For standalone purposes, we store the ID.
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/puzzle-timers/puzzle-timers.controller.ts
+++ b/src/puzzle-timers/puzzle-timers.controller.ts
@@ -1,0 +1,52 @@
+// src/puzzle-timers/puzzle-timers.controller.ts
+
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { PuzzleTimersService } from './puzzle-timers.service';
+import { CreatePuzzleTimerDto } from './dto/create-puzzle-timer.dto';
+import { UpdatePuzzleTimerDto } from './dto/update-puzzle-timer.dto';
+
+@Controller('puzzle-timers')
+export class PuzzleTimersController {
+  constructor(private readonly puzzleTimersService: PuzzleTimersService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() createPuzzleTimerDto: CreatePuzzleTimerDto) {
+    return this.puzzleTimersService.create(createPuzzleTimerDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.puzzleTimersService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', new ParseUUIDPipe()) id: string) {
+    return this.puzzleTimersService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() updatePuzzleTimerDto: UpdatePuzzleTimerDto,
+  ) {
+    return this.puzzleTimersService.update(id, updatePuzzleTimerDto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  remove(@Param('id', new ParseUUIDPipe()) id: string) {
+    return this.puzzleTimersService.remove(id);
+  }
+}

--- a/src/puzzle-timers/puzzle-timers.module.ts
+++ b/src/puzzle-timers/puzzle-timers.module.ts
@@ -1,0 +1,15 @@
+// src/puzzle-timers/puzzle-timers.module.ts
+
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PuzzleTimersService } from './puzzle-timers.service';
+import { PuzzleTimersController } from './puzzle-timers.controller';
+import { PuzzleTimer } from './entities/puzzle-timer.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PuzzleTimer])],
+  controllers: [PuzzleTimersController],
+  providers: [PuzzleTimersService],
+  exports: [PuzzleTimersService], // Optional: export if other modules need this service
+})
+export class PuzzleTimersModule {}

--- a/src/puzzle-timers/puzzle-timers.service.ts
+++ b/src/puzzle-timers/puzzle-timers.service.ts
@@ -1,0 +1,65 @@
+// src/puzzle-timers/puzzle-timers.service.ts
+
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreatePuzzleTimerDto } from './dto/create-puzzle-timer.dto';
+import { UpdatePuzzleTimerDto } from './dto/update-puzzle-timer.dto';
+import { PuzzleTimer } from './entities/puzzle-timer.entity';
+
+@Injectable()
+export class PuzzleTimersService {
+  constructor(
+    @InjectRepository(PuzzleTimer)
+    private readonly timerRepository: Repository<PuzzleTimer>,
+  ) {}
+
+  create(createPuzzleTimerDto: CreatePuzzleTimerDto): Promise<PuzzleTimer> {
+    const timer = this.timerRepository.create({
+      ...createPuzzleTimerDto,
+      startTime: new Date(createPuzzleTimerDto.startTime),
+      endTime: new Date(createPuzzleTimerDto.endTime),
+    });
+    return this.timerRepository.save(timer);
+  }
+
+  findAll(): Promise<PuzzleTimer[]> {
+    return this.timerRepository.find();
+  }
+
+  async findOne(id: string): Promise<PuzzleTimer> {
+    const timer = await this.timerRepository.findOneBy({ id });
+    if (!timer) {
+      throw new NotFoundException(`Timer with ID "${id}" not found`);
+    }
+    return timer;
+  }
+
+  async update(
+    id: string,
+    updatePuzzleTimerDto: UpdatePuzzleTimerDto,
+  ): Promise<PuzzleTimer> {
+    const timer = await this.timerRepository.preload({
+      id,
+      ...updatePuzzleTimerDto,
+      // Ensure date strings are converted to Date objects if they exist
+      ...(updatePuzzleTimerDto.startTime && {
+        startTime: new Date(updatePuzzleTimerDto.startTime),
+      }),
+      ...(updatePuzzleTimerDto.endTime && {
+        endTime: new Date(updatePuzzleTimerDto.endTime),
+      }),
+    });
+
+    if (!timer) {
+      throw new NotFoundException(`Timer with ID "${id}" not found`);
+    }
+    return this.timerRepository.save(timer);
+  }
+
+  async remove(id: string): Promise<{ id: string; message: string }> {
+    const timer = await this.findOne(id);
+    await this.timerRepository.remove(timer);
+    return { id, message: 'Successfully deleted timer.' };
+  }
+}


### PR DESCRIPTION
### PR: feat: Create Puzzle Timers Module #146

**Summary**

This pull request introduces a new standalone `PuzzleTimersModule` to manage time limits for puzzles, addressing issue #146. The module is fully independent and provides complete CRUD functionality for puzzle timers.

**Changes**

-   **Entity:** Created `PuzzleTimer` entity with `id`, `startTime`, `endTime`, `challengeId`, `createdAt`, and `updatedAt` fields.
-   **DTOs:** Added `CreatePuzzleTimerDto` and `UpdatePuzzleTimerDto` with `class-validator` rules for robust input validation.
-   **Service:** Implemented `PuzzleTimersService` to handle all business logic for creating, reading, updating, and deleting timers.
-   **Controller:** Set up `PuzzleTimersController` with RESTful endpoints (`POST`, `GET`, `PATCH`, `DELETE`) to expose the service logic via HTTP.
-   **Module:** Encapsulated all components within the `PuzzleTimersModule` and configured TypeORM repository injection.

**How to Test**

1.  Run the application.
2.  Use an API client (like Postman or Insomnia) to test the following endpoints:
    -   `POST /puzzle-timers`
    -   `GET /puzzle-timers`
    -   `GET /puzzle-timers/:id`
    -   `PATCH /puzzle-timers/:id`
    -   `DELETE /puzzle-timers/:id`
3.  Verify that all operations work as expected and that input validation is enforced.

Closes #146